### PR TITLE
Suffix menus with (NEW) (RDEV-7047)

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ class MultiWorkFiles(sgtk.platform.Application):
 
         # register the file open command
         self.engine.register_command(
-            "File Open...",
+            "File Open... (NEW)",
             self.show_file_open_dlg,
             {
                 "short_name": "file_open",
@@ -54,7 +54,7 @@ class MultiWorkFiles(sgtk.platform.Application):
 
         # register the file save command
         self.engine.register_command(
-            "File Save...",
+            "File Save... (NEW)",
             self.show_file_save_dlg,
             {
                 "short_name": "file_save",

--- a/info.yml
+++ b/info.yml
@@ -183,7 +183,7 @@ configuration:
 requires_shotgun_fields:
 
 # More verbose description of this item 
-display_name: "Shotgun Workfiles"
+display_name: "Shotgun Workfiles (NEW)"
 description: "Using this app you can browse, open and save your Work Files and Publishes."
               
 # Required minimum versions for this item to run


### PR DESCRIPTION
To accommodate the users with the new app and to easily differentiate between the old app and the new app, I had to fork the app and add a `(NEW)` suffix in the Shotgun menu.

**This is temporary and will be removed after a couple of weeks**