### PR TITLE
Deprecate tk-multi-workfiles in Maya (DEV-13210)

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ class MultiWorkFiles(sgtk.platform.Application):
 
         # register the file open command
         self.engine.register_command(
-            "File Open... (NEW)",
+            "File Open...",
             self.show_file_open_dlg,
             {
                 "short_name": "file_open",
@@ -54,7 +54,7 @@ class MultiWorkFiles(sgtk.platform.Application):
 
         # register the file save command
         self.engine.register_command(
-            "File Save... (NEW)",
+            "File Save...",
             self.show_file_save_dlg,
             {
                 "short_name": "file_save",

--- a/info.yml
+++ b/info.yml
@@ -197,7 +197,7 @@ configuration:
 requires_shotgun_fields:
 
 # More verbose description of this item 
-display_name: "Shotgun Workfiles (NEW)"
+display_name: "Shotgun Workfiles"
 description: "Using this app you can browse, open and save your Work Files and Publishes."
               
 # Required minimum versions for this item to run


### PR DESCRIPTION
#### Purpose of the PR / What does this do?
This PR remove the " (NEW)" suffix in the menu.

#### Overview of the changes (don't assume any history)
In the past theses suffix where added to accomodate users because tk-multi-workfiles and tk-multi-workfiles2 where used at the same time in Maya. (https://github.com/rodeofx/tk-multi-workfiles2/pull/1)

Since tk-multi-workfiles is not maintained upstream anymore and caused issues in maya-2018, we decided to remove it. The suffix is hence not needed anymore.

#### Type of feedback wanted
Any feedback is welcome, this should be straightforward.

#### Where should the reviewer start looking at?
Clone the repo, then in rdo_tk_config, change the tk-multi-workfiles2 location to a path descriptor pointing to your clone.

#### Potential risks of this change, if any.
None

#### Relationship with other PRs (with links!)
This PR is related to pull-request 37 on rdo_tk_config.